### PR TITLE
Tidy file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ In separate terminal windows and follow on-screen prompts
 
 #### Or to use the TCP bot:
 ```
-$ python tcp/tcp_server.py
+$ python tcp/server.py
 ```
 ```
-$ python tcp/tcp_client.py
+$ python tcp/client.py
 ```
 In separate terminal windows and follow on-screen prompts
 

--- a/tcp/client.py
+++ b/tcp/client.py
@@ -1,8 +1,8 @@
 import datetime, logging, socket
 import config
-from tcp_recvall import TcpRecvall
+from recvall import Recvall
 
-class TcpClient():
+class Client():
     def __init__(self):
         self.logger = logging.getLogger()
             
@@ -23,10 +23,10 @@ class TcpClient():
 
         message = dt.encode('UTF-8')
         s.sendall(message)
-        reply = TcpRecvall.send(self, sock=s, length=31)
+        reply = Recvall.send(self, sock=s, length=31)
         print('The server replied with {!r}'.format(reply.decode('UTF-8')))
         print('Closing socket')
         s.close()
 
 if __name__ == '__main__':
-    TcpClient().run()
+    Client().run()

--- a/tcp/recvall.py
+++ b/tcp/recvall.py
@@ -1,6 +1,6 @@
 import logging
 
-class TcpRecvall():
+class Recvall():
     def __init__(self):
         self.logger = logging.getLogger()
 

--- a/tcp/server.py
+++ b/tcp/server.py
@@ -1,8 +1,8 @@
 import calendar, datetime, logging, socket
 from tcp import config
-from tcp.tcp_recvall import TcpRecvall
+from tcp.recvall import Recvall
 
-class TcpServer():
+class Server():
     def __init__(self):
         self.logger = logging.getLogger()
  
@@ -20,7 +20,7 @@ class TcpServer():
             print('Socket name:', sc.getsockname())
             print('Socket peer:', sc.getpeername())
 
-            data = TcpRecvall.send(self, sock=sc, length=10)
+            data = Recvall.send(self, sock=sc, length=10)
             print('Message from client:', data.decode('UTF-8'))
             message = data.decode('UTF-8')
             day_born=self.get_week_day(message)
@@ -36,4 +36,4 @@ class TcpServer():
         return (calendar.day_name[born]) 
 
 if __name__ == '__main__':
-    TcpServer().run()
+    Server().run()

--- a/tcp/tests/test_server.py
+++ b/tcp/tests/test_server.py
@@ -1,9 +1,9 @@
 import unittest
-from tcp.tcp_server import TcpServer
+from tcp.server import Server
 
 class TestTcpServer(unittest.TestCase):
     def setUp(self):
-        self.server = TcpServer()
+        self.server = Server()
 
     def test_get_week_day_1(self):
         dt = '05-05-1992'

--- a/udp/client.py
+++ b/udp/client.py
@@ -1,7 +1,7 @@
 import logging, socket
 from udp import constants
 
-class UdpClient():
+class Client():
     def __init__(self):
         self.logger = logging.getLogger()
 
@@ -18,4 +18,4 @@ class UdpClient():
             print('The server {} replied with {!r}'.format(address, text))
 
 if __name__ == '__main__':
-    UdpClient().run()
+    Client().run()

--- a/udp/server.py
+++ b/udp/server.py
@@ -1,7 +1,7 @@
 import argparse, calendar, datetime, logging, socket
 from udp import constants
 
-class UdpServer():
+class Server():
     def __init__(self):
         self.logger = logging.getLogger()
 
@@ -39,4 +39,4 @@ class UdpServer():
         return (calendar.day_name[born]) 
 
 if __name__ == '__main__':
-    UdpServer().run()
+    Server().run()

--- a/udp/tests/test_server.py
+++ b/udp/tests/test_server.py
@@ -1,9 +1,9 @@
 import unittest
-from udp.udp_server import UdpServer
+from udp.server import Server
 
 class TestUdpServer(unittest.TestCase):
     def setUp(self):
-        self.server = UdpServer()
+        self.server = Server()
 
     def test_validate_input_1(self):
         message = '2001'


### PR DESCRIPTION
# Overview

This small PR just changes the file naming convention, making the file paths more succinct

# Details

* Change all examples of double naming e.g. `tcp/tcp_server` -> `tcp/server` 
* Add prerequisite section to README